### PR TITLE
Bugfixes for cell counts and energy display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App() {
       } else {
         alert('Invalid cell data in clipboard')
       }
-    } catch (error) {
+    } catch {
       alert('Failed to read clipboard')
     }
   }, [enableRepeatGeneration, handleStart])

--- a/src/components/SimulationCanvas.tsx
+++ b/src/components/SimulationCanvas.tsx
@@ -24,7 +24,8 @@ export const SimulationCanvas: React.FC<Props> = ({ params, state, onStateChange
 
     // Initialize the simulation
     simulationRef.current.initialize(params, geneMatrixRef.current)
-    onStateChange({ frameCount: 0 })
+    const stats = simulationRef.current.getStats()
+    onStateChange({ frameCount: 0, cellCount: stats.cellCount, totalEnergy: stats.totalEnergy })
   }, [params, copiedGenes, onStateChange])
 
   const runSimulationStep = useCallback(() => {
@@ -67,6 +68,7 @@ export const SimulationCanvas: React.FC<Props> = ({ params, state, onStateChange
         cancelAnimationFrame(animationRef.current)
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Handle simulation initialization when parameters change

--- a/src/shaders/init2Shader.glsl
+++ b/src/shaders/init2Shader.glsl
@@ -5,6 +5,7 @@ uniform sampler2D u_cellTexture1; // To check which cells exist
 uniform vec2 u_resolution;
 uniform vec2 u_maxEnergyToGetRange;
 uniform float u_geneMatrixSize;
+uniform float u_geneMatrixHeight;
 
 in vec2 v_texCoord;
 out vec4 fragColor;
@@ -32,8 +33,8 @@ void main() {
         // energyFromSun (starts at 0)
         cell2.z = 0.0;
 
-        // activeGen (random starting gene order)
-        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixSize);
+        // activeGen (random starting gene sequence)
+        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixHeight);
     }
 
     fragColor = cell2;

--- a/src/shaders/initShader.glsl
+++ b/src/shaders/initShader.glsl
@@ -8,6 +8,7 @@ uniform vec2 u_willRange;
 uniform vec2 u_maxEnergyRange;
 uniform vec2 u_maxEnergyToGetRange;
 uniform float u_geneMatrixSize; // width * height
+uniform float u_geneMatrixHeight; // rows
 
 in vec2 v_texCoord;
 out vec4 fragColor;
@@ -54,8 +55,8 @@ void main() {
         // energyFromSun (starts at 0)
         cell2.z = 0.0;
 
-        // activeGen (random starting gene order)
-        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixSize);
+        // activeGen (random starting gene sequence)
+        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixHeight);
     }
 
     // Output characteristics (we'll use two textures to store all 8 values)

--- a/src/shaders/resolve2Shader.glsl
+++ b/src/shaders/resolve2Shader.glsl
@@ -108,8 +108,9 @@ void main() {
                           }
     }
 
-    // Clear fields if cell died
+    // Clear fields if cell died and store remaining energy
     if (cell1Old.x > 0.0 && cell1.x == 0.0) {
+        newCell2.y += cell1Old.y;
         newCell2.x = 0.0;
         newCell2.z = 0.0;
         newCell2.w = 0.0;

--- a/src/shaders/resolveShader.glsl
+++ b/src/shaders/resolveShader.glsl
@@ -101,12 +101,12 @@ void main() {
         float action = myIntention.x;
 
         if (action >= 1.0 && action <= 4.0) { // Division
-                                              // Halve my energy if division succeeded
                                               vec2 targetPos = vec2(myIntention.y, myIntention.z);
                                               vec4 targetCell = texture(u_cellTexture1, targetPos / u_resolution);
-                                              if (targetCell.x == 0.0) { // Target was empty
-                                                                         newCell1.y *= 0.5;
+                                              if (targetCell.x == 0.0) {
+                                                  newCell1.y *= 0.5; // Successful division
                                               }
+                                              newCell1.y -= newCell1.w; // Energy cost
         }
         else if (action == 5.0) { // Extract energy
                                   float extracted = myIntention.w;
@@ -116,8 +116,11 @@ void main() {
                                   float solar = myIntention.w;
                                   newCell1.y = min(newCell1.y + solar - newCell1.w, newCell1.z);
         }
+        else if (action >= 7.0 && action <= 10.0) { // Transfer energy
+                                              float amount = myIntention.w;
+                                              newCell1.y = max(newCell1.y - (amount + newCell1.w), 0.0);
+        }
         else if (action >= 11.0 && action <= 13.0) { // Suicide pixel actions
-                                                     // Cell dies
                                                      newCell1 = vec4(0.0);
         }
     }
@@ -148,6 +151,10 @@ void main() {
                 }
             }
         }
+    }
+
+    if (newCell1.x > 0.0 && newCell1.y <= 0.0) {
+        newCell1 = vec4(0.0);
     }
 
     fragColor = newCell1;

--- a/src/utils/WebGLSimulation.ts
+++ b/src/utils/WebGLSimulation.ts
@@ -109,6 +109,7 @@ export class WebGLSimulation {
     this.setUniform2f('u_maxEnergyRange', params.maxEnergyRange[0], params.maxEnergyRange[1])
     this.setUniform2f('u_maxEnergyToGetRange', params.maxEnergyToGetRange[0], params.maxEnergyToGetRange[1])
     this.setUniform1f('u_geneMatrixSize', params.geneMatrixWidth * params.geneMatrixHeight)
+    this.setUniform1f('u_geneMatrixHeight', params.geneMatrixHeight)
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers.cellTexture1A)
     gl.viewport(0, 0, params.width, params.height)
@@ -120,6 +121,7 @@ export class WebGLSimulation {
     this.setUniform2f('u_resolution', params.width, params.height)
     this.setUniform2f('u_maxEnergyToGetRange', params.maxEnergyToGetRange[0], params.maxEnergyToGetRange[1])
     this.setUniform1f('u_geneMatrixSize', params.geneMatrixWidth * params.geneMatrixHeight)
+    this.setUniform1f('u_geneMatrixHeight', params.geneMatrixHeight)
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers.cellTexture2A)
     gl.viewport(0, 0, params.width, params.height)

--- a/src/utils/simulation.ts
+++ b/src/utils/simulation.ts
@@ -1,4 +1,4 @@
-import { SimulationParams, CellData } from '../types/simulation'
+import { SimulationParams, CellData, SunMode } from '../types/simulation'
 
 export function generateRandomGeneMatrix(width: number, height: number): number[][] {
   const matrix: number[][] = []
@@ -54,7 +54,7 @@ export function getDefaultParams(): SimulationParams {
 
     maxSolarEnergy: 2,
     dayCycleDuration: 1000,
-    sunMode: 'constant_full' as any,
+    sunMode: SunMode.CONSTANT_FULL,
 
     showAccumulatedEnergy: true,
     showSunEnergy: true,


### PR DESCRIPTION
## Summary
- update initialization to report accurate stats
- fix shader initial `activeGen` range with new `u_geneMatrixHeight`
- apply energy costs and death logic so cells divide and leave energy

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'GPUCanvasContext')*

------
https://chatgpt.com/codex/tasks/task_e_684db3ba4cfc8333862521a549edd1bf