### PR TITLE
Fix cell initialization and energy mechanics

### DIFF
--- a/src/components/SimulationCanvas.tsx
+++ b/src/components/SimulationCanvas.tsx
@@ -24,7 +24,8 @@ export const SimulationCanvas: React.FC<Props> = ({ params, state, onStateChange
 
     // Initialize the simulation
     simulationRef.current.initialize(params, geneMatrixRef.current)
-    onStateChange({ frameCount: 0 })
+    const stats = simulationRef.current.getStats()
+    onStateChange({ frameCount: 0, cellCount: stats.cellCount, totalEnergy: stats.totalEnergy })
   }, [params, copiedGenes, onStateChange])
 
   const runSimulationStep = useCallback(() => {
@@ -75,6 +76,13 @@ export const SimulationCanvas: React.FC<Props> = ({ params, state, onStateChange
       initializeSimulation()
     }
   }, [params, copiedGenes, state.running, initializeSimulation])
+
+  // Reinitialize when starting a new run
+  useEffect(() => {
+    if (simulationRef.current && state.running && state.frameCount === 0) {
+      initializeSimulation()
+    }
+  }, [state.running, state.frameCount, initializeSimulation])
 
   // Handle animation loop
   useEffect(() => {

--- a/src/shaders/init2Shader.glsl
+++ b/src/shaders/init2Shader.glsl
@@ -5,6 +5,7 @@ uniform sampler2D u_cellTexture1; // To check which cells exist
 uniform vec2 u_resolution;
 uniform vec2 u_maxEnergyToGetRange;
 uniform float u_geneMatrixSize;
+uniform float u_geneMatrixHeight;
 
 in vec2 v_texCoord;
 out vec4 fragColor;
@@ -32,8 +33,8 @@ void main() {
         // energyFromSun (starts at 0)
         cell2.z = 0.0;
 
-        // activeGen (random starting gene order)
-        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixSize);
+        // activeGen (random starting gene row)
+        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixHeight);
     }
 
     fragColor = cell2;

--- a/src/shaders/initShader.glsl
+++ b/src/shaders/initShader.glsl
@@ -7,7 +7,8 @@ uniform float u_initialEnergyMultiplier;
 uniform vec2 u_willRange;
 uniform vec2 u_maxEnergyRange;
 uniform vec2 u_maxEnergyToGetRange;
-uniform float u_geneMatrixSize; // width * height
+uniform float u_geneMatrixSize;  // width * height
+uniform float u_geneMatrixHeight; // number of rows in gene matrix
 
 in vec2 v_texCoord;
 out vec4 fragColor;
@@ -54,8 +55,8 @@ void main() {
         // energyFromSun (starts at 0)
         cell2.z = 0.0;
 
-        // activeGen (random starting gene order)
-        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixSize);
+        // activeGen (random starting gene row)
+        cell2.w = floor(hash(coord + vec2(4.0, 0.0)) * u_geneMatrixHeight);
     }
 
     // Output characteristics (we'll use two textures to store all 8 values)

--- a/src/shaders/resolve2Shader.glsl
+++ b/src/shaders/resolve2Shader.glsl
@@ -108,8 +108,9 @@ void main() {
                           }
     }
 
-    // Clear fields if cell died
+    // Clear fields if cell died and store remaining energy in the pixel
     if (cell1Old.x > 0.0 && cell1.x == 0.0) {
+        newCell2.y += cell1Old.y;
         newCell2.x = 0.0;
         newCell2.z = 0.0;
         newCell2.w = 0.0;

--- a/src/shaders/resolveShader.glsl
+++ b/src/shaders/resolveShader.glsl
@@ -150,5 +150,9 @@ void main() {
         }
     }
 
+    if (newCell1.x > 0.0 && newCell1.y <= 0.0) {
+        newCell1 = vec4(0.0);
+    }
+
     fragColor = newCell1;
 }

--- a/src/utils/WebGLSimulation.ts
+++ b/src/utils/WebGLSimulation.ts
@@ -109,6 +109,7 @@ export class WebGLSimulation {
     this.setUniform2f('u_maxEnergyRange', params.maxEnergyRange[0], params.maxEnergyRange[1])
     this.setUniform2f('u_maxEnergyToGetRange', params.maxEnergyToGetRange[0], params.maxEnergyToGetRange[1])
     this.setUniform1f('u_geneMatrixSize', params.geneMatrixWidth * params.geneMatrixHeight)
+    this.setUniform1f('u_geneMatrixHeight', params.geneMatrixHeight)
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers.cellTexture1A)
     gl.viewport(0, 0, params.width, params.height)
@@ -120,6 +121,7 @@ export class WebGLSimulation {
     this.setUniform2f('u_resolution', params.width, params.height)
     this.setUniform2f('u_maxEnergyToGetRange', params.maxEnergyToGetRange[0], params.maxEnergyToGetRange[1])
     this.setUniform1f('u_geneMatrixSize', params.geneMatrixWidth * params.geneMatrixHeight)
+    this.setUniform1f('u_geneMatrixHeight', params.geneMatrixHeight)
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.framebuffers.cellTexture2A)
     gl.viewport(0, 0, params.width, params.height)


### PR DESCRIPTION
## Summary
- ensure new simulations reinitialize WebGL state and report starting stats
- fix gene row selection in init shaders
- add cell death and energy field accumulation logic

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_684db3ba4cfc8333862521a549edd1bf